### PR TITLE
fix: ssm param reference

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -16,7 +16,7 @@ To do the deploy to new env follow these steps:
    ```
 1. Apply the terraform and fill in the values - only needed on the first deploy or when adding new value
    ```sh
-   AWS_PROFILE=<profile> terraform apply
+   cd ./infra/terraform && AWS_PROFILE=<profile> terraform apply
    ```
 1. Deploy the app - preferably let the CI deploy job handle this.
    ```sh

--- a/infra/cdk/stack/ssm-parameters.ts
+++ b/infra/cdk/stack/ssm-parameters.ts
@@ -9,7 +9,7 @@ import { type createCognito } from './cognito';
 export function getStringParameters(scope: Construct) {
   const sentryDsn = StringParameter.fromStringParameterName(
     scope,
-    'sentry-dsn',
+    'sentry-dsn-param',
     'pdf-generator-api-sentry-dsn',
   );
 

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -13,7 +13,7 @@ provider "aws" {
 
 resource "aws_ssm_parameter" "sentry_dsn" {
   name = "pdf-generator-api-sentry-dsn"
-  type = "SecureString"
+  type = "String"
   value = var.sentry_dsn
 
   lifecycle {


### PR DESCRIPTION
### Description

We are chaning SENTRY DSN SSM param from secure string to plain string to be able to reference it using `StringParameter.fromStringParameterName`. As this is not sensitive value - value is often present in FE code that uses Sentry, this isn't security thread.

### Checklist

- [x] I have performed self-review of my code
- [ ] I have updated the OpenAPI documentation - not relevant
- [ ] I have written tests covering the newly added or changed logic - not relevant, just infra change
- [x] Changes are backward compatible (if not, specify breaking changes)
