### PR TITLE
feat: use random bucket name

### DIFF
--- a/infra/cdk/stack/index.ts
+++ b/infra/cdk/stack/index.ts
@@ -44,7 +44,6 @@ export class CdkStack extends Stack {
       autoDeleteObjects: !retainStatefulResources,
       removalPolicy,
       scope: this,
-      stackId: id,
     });
     const kmsKey = createKmsKey({ removalPolicy, scope: this, stackId: id });
 

--- a/infra/cdk/stack/s3.ts
+++ b/infra/cdk/stack/s3.ts
@@ -6,16 +6,13 @@ export function createS3Bucket({
   autoDeleteObjects,
   removalPolicy,
   scope,
-  stackId,
 }: {
   autoDeleteObjects: boolean;
   removalPolicy: RemovalPolicy;
   scope: Construct;
-  stackId: string;
 }) {
   const bucket = new Bucket(scope, 's3-bucket', {
     autoDeleteObjects,
-    bucketName: stackId,
     enforceSSL: true,
     removalPolicy,
   });


### PR DESCRIPTION
### Description

Switching to using random bucket name - as bucket name has to be globally unique across AWS, we don't want to risk having conflicting name.

We will migrate existing data manually from old to new bucket.

### Checklist

- [x] I have performed self-review of my code
- [ ] I have updated the OpenAPI documentation - not relevant
- [ ] I have written tests covering the newly added or changed logic - not relevant
- [x] Changes are backward compatible (if not, specify breaking changes) - we need to manually migrate data, but for consumers this isn't a breaking change as we use bucket only internally.
