### PR TITLE
chore: pin CI dependencies by hash

### DIFF
--- a/.github/workflows/ci-cd.workflow.yml
+++ b/.github/workflows/ci-cd.workflow.yml
@@ -17,8 +17,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: '.nvmrc'
       - run: npm ci
@@ -26,8 +26,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: '.nvmrc'
       - run: npm ci
@@ -35,8 +35,8 @@ jobs:
   test-it:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: '.nvmrc'
       - run: npm ci
@@ -48,15 +48,15 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: '.nvmrc'
       - run: npm ci
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
         with:
           platforms: 'arm64,arm'
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: 'eu-central-1'
@@ -64,7 +64,7 @@ jobs:
         env:
           REQUIRE_APPROVAL: never
           ENVIRONMENT_NAME: ${{ secrets.ENVIRONMENT_NAME }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: cdk-output
           path: ./infra/cdk/cdk.output.json
@@ -76,15 +76,15 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: '.nvmrc'
       - run: npm ci
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: cdk-output
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: 'eu-central-1'

--- a/docs/architecture-decision-records/009-pin-ci-dependencies-by-hash.md
+++ b/docs/architecture-decision-records/009-pin-ci-dependencies-by-hash.md
@@ -1,0 +1,50 @@
+# Pin CI dependencies by hash
+
+## Context
+
+The CI/CD pipeline uses GitHub Actions and Docker images referenced by mutable tags such as `actions/checkout@v4` or `amazon/dynamodb-local:3.3.0`. Mutable tags can be silently updated by their maintainers at any time. A tag like `v4` is a floating pointer - the maintainer can move it to a new commit without any notification.
+
+This means:
+
+- A compromised maintainer account or a supply-chain attack can push malicious code under an existing tag, causing it to execute in our pipeline with full access to repository secrets (AWS deploy role ARN, environment names). This was a case e.g. in a recent Trivy hack.
+- A workflow that passed today may fail or behave differently tomorrow due to a change outside our control.
+- There is no way to detect that an action or image has changed between two runs when referencing by tag alone.
+
+## Decision
+
+Reference all GitHub Actions by their full commit SHA and all Docker images by their `sha256` content digest. The human-readable tag is retained as a comment so the intent remains clear:
+
+GitHub Actions:
+
+```yaml
+uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+```
+
+Docker images:
+
+```yaml
+image: amazon/dynamodb-local@sha256:d89f8fcc6b1a39cb35976c248ed42a28c66ae00dc043099210f5571e42648ab4 # v3.3.0
+```
+
+A SHA is immutable. If a maintainer moves a tag, our pipeline continues to use exactly the code that was audited. Any update requires an explicit change in this repository, producing a diff that can be reviewed.
+
+## Alternatives considered
+
+### Continue using mutable tags
+
+Simple to read and update. We choose not to accept this, as it silently exposes the pipeline to upstream changes and supply-chain attacks. A compromised `actions/checkout` would have full read access to the checked-out source and all secrets available to the job.
+
+### Dependabot for automated hash updates
+
+Automated tools can open PRs to update pinned SHAs when new versions are released, combining immutability with staying current. We choose not to adopt this immediately as the added tooling complexity is not yet justified, but it is a natural follow-on when the number of pinned dependencies grows.
+
+### Fork and self-host all actions
+
+Complete control over action code with no dependency on upstream maintainers. We choose not to do this, as the maintenance overhead of keeping forks current is higher than the residual risk of using pinned upstream SHAs from well-known publishers (GitHub, AWS, Docker).
+
+## Consequences
+
+- Supply-chain attacks that move a tag to malicious code have no effect on the pipeline.
+- Pipeline executions are fully reproducible - the same SHA runs every time.
+- Updating an action or image requires an intentional, reviewable commit — there are no silent upgrades.
+- The human-readable tag comment preserves readability and makes it easy to assess whether an update is needed.

--- a/infra/local/docker-compose-app.yml
+++ b/infra/local/docker-compose-app.yml
@@ -2,7 +2,7 @@ name: pdf-generator-api
 services:
   dynamodb-local:
     command: '-jar DynamoDBLocal.jar -sharedDb -dbPath ./data'
-    image: 'amazon/dynamodb-local:latest'
+    image: 'amazon/dynamodb-local@sha256:d89f8fcc6b1a39cb35976c248ed42a28c66ae00dc043099210f5571e42648ab4' # v3.3.0
     ports:
       - '8000:8000'
     volumes:
@@ -18,7 +18,7 @@ services:
       timeout: 3s
       retries: 10
   dynamodb-admin:
-    image: aaronshaf/dynamodb-admin
+    image: aaronshaf/dynamodb-admin@sha256:46d9c7f5234688481a807987113ab068acaa11fd7057c9bb84ef181f492a0194 # v5.1.3
     ports:
       - '8001:8001'
     environment:

--- a/infra/local/docker-compose-app.yml
+++ b/infra/local/docker-compose-app.yml
@@ -2,7 +2,7 @@ name: pdf-generator-api
 services:
   dynamodb-local:
     command: '-jar DynamoDBLocal.jar -sharedDb -dbPath ./data'
-    image: 'amazon/dynamodb-local@sha256:d89f8fcc6b1a39cb35976c248ed42a28c66ae00dc043099210f5571e42648ab4' # v3.3.0
+    image: amazon/dynamodb-local@sha256:d89f8fcc6b1a39cb35976c248ed42a28c66ae00dc043099210f5571e42648ab4 # v3.3.0
     ports:
       - '8000:8000'
     volumes:

--- a/infra/local/docker-compose-it.yml
+++ b/infra/local/docker-compose-it.yml
@@ -2,7 +2,7 @@ name: pdf-generator-api-it
 services:
   dynamodb-local-it:
     command: '-jar DynamoDBLocal.jar -sharedDb'
-    image: 'amazon/dynamodb-local@sha256:d89f8fcc6b1a39cb35976c248ed42a28c66ae00dc043099210f5571e42648ab4' # v3.3.0
+    image: amazon/dynamodb-local@sha256:d89f8fcc6b1a39cb35976c248ed42a28c66ae00dc043099210f5571e42648ab4 # v3.3.0
     ports:
       - '7999:8000'
     healthcheck:

--- a/infra/local/docker-compose-it.yml
+++ b/infra/local/docker-compose-it.yml
@@ -2,7 +2,7 @@ name: pdf-generator-api-it
 services:
   dynamodb-local-it:
     command: '-jar DynamoDBLocal.jar -sharedDb'
-    image: 'amazon/dynamodb-local:latest'
+    image: 'amazon/dynamodb-local@sha256:d89f8fcc6b1a39cb35976c248ed42a28c66ae00dc043099210f5571e42648ab4' # v3.3.0
     ports:
       - '7999:8000'
     healthcheck:

--- a/package.json
+++ b/package.json
@@ -90,5 +90,6 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.2",
     "wait-for-expect": "^4.0.0"
-  }
+  },
+  "packageManager": "npm@11.12.1"
 }


### PR DESCRIPTION
### Description

Switches pinning of GitHub actions and Docker images to use full sha hashes instead of mutable tags to mitigate risk of supply-chain attacks.

### Checklist

- [x] I have performed self-review of my code
- [ ] I have updated the OpenAPI documentation - not relevant
- [ ] I have written tests covering the newly added or changed logic - not relevant
- [x] Changes are backward compatible (if not, specify breaking changes)
